### PR TITLE
Add ICLR 2026 poster link to Hubble publication

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,6 +158,7 @@
                      [<a href="https://github.com/allegro-lab/hubble">github</a>]
                      [<a href="https://allegro-lab.github.io/hubble/">website</a>]
                      [<a href="https://recorder-v3.slideslive.com/#/share?share=110015&s=daaf0b25-1284-4418-a46f-3b62cfbe1e06">video</a>]
+                     [<a href="https://iclr.cc/media/PosterPDFs/ICLR%202026/10008788.png?t=1775689035.6679373">poster</a>]
                      [<a href="https://www.science.org/content/article/ais-can-memorize-data-they-shouldn-t-can-they-be-forced-forget">press</a>]
                      <div id="hubble_abstract" class="abstract" style="display:none;">
                         <p>


### PR DESCRIPTION
## Summary
Added a poster link to the Hubble publication entry in the selected publications section.

## Changes
- Added a new poster link pointing to the ICLR 2026 poster PDF for the Hubble paper
- The link is positioned alongside existing resources (GitHub, website, video, and press links)

## Details
The poster link references the official ICLR 2026 poster PDF hosted on the conference media server, providing readers with an additional resource to understand the Hubble research presentation.

https://claude.ai/code/session_01FWtumeLfPXewTmTwPU1StE