### PR TITLE
Add NAIRR proposal link to Hubble publication

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,6 +159,7 @@
                      [<a href="https://allegro-lab.github.io/hubble/">website</a>]
                      [<a href="https://recorder-v3.slideslive.com/#/share?share=110015&s=daaf0b25-1284-4418-a46f-3b62cfbe1e06">video</a>]
                      [<a href="https://iclr.cc/media/PosterPDFs/ICLR%202026/10008788.png?t=1775689035.6679373">poster</a>]
+                     [<a href="pdfs/NAIRR_Proposal.pdf">proposal</a>]
                      [<a href="https://www.science.org/content/article/ais-can-memorize-data-they-shouldn-t-can-they-be-forced-forget">press</a>]
                      <div id="hubble_abstract" class="abstract" style="display:none;">
                         <p>


### PR DESCRIPTION
## Summary
Added a link to the NAIRR proposal PDF in the Hubble publication entry on the publications page.

## Changes
- Added a new link to `pdfs/NAIRR_Proposal.pdf` in the Hubble publication's reference section
- The proposal link is positioned between the poster and press links, maintaining consistent formatting with other reference links

## Details
This change makes the NAIRR proposal document easily accessible from the publication listing, allowing visitors to view the proposal alongside other related materials (website, video, poster, and press coverage).

https://claude.ai/code/session_014rBVwJEsW2PxxoKgjU95AP