### PR TITLE
Update publication venue for spiking neural networks paper

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
                      <a href="https://ameyagodbole.github.io/">Ameya Godbole</a>,
                      and <a href="https://robinjia.github.io/">Robin Jia</a>.
                      <br/>
-                     Preprint.
+                     <a href="https://aimslab.stanford.edu/workshop"><b>AIMS</b></a> workshop at <b>COLM</b> 2026.
                      <br/>
                      [<a href="#" onclick="$('#spiking_abstract').toggle();return false;">abstract</a>]
                      <div id="spiking_abstract" class="abstract" style="display:none;">


### PR DESCRIPTION
## Summary
Updated the publication status of the spiking neural networks paper from a preprint to a workshop paper accepted at the AIMS workshop at COLM 2026.

## Changes
- Changed the publication status from "Preprint." to a linked workshop venue: "AIMS workshop at COLM 2026"
- Added hyperlink to the AIMS workshop website (https://aimslab.stanford.edu/workshop)
- Applied bold formatting to both "AIMS" and "COLM" for emphasis

## Details
This update reflects that the paper has been accepted to the AIMS (AI for Math and Science) workshop at the Conference on Language Modeling (COLM) 2026, replacing its previous preprint status.

https://claude.ai/code/session_01HLFDCnSsBqK8xcNBdRJRzF