### PR TITLE
Update publication title wording

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
                   <br/>
                   <li>
                      <a href="https://arxiv.org/pdf/2605.24818">
-                     <b>Spiking the training data to correct for test set contamination</b>
+                     <b>Correcting test set contamination by spiking the training data</b>
                      </a>
                      <br/>
                      <b>Johnny Tian-Zheng Wei</b>*,


### PR DESCRIPTION
## Summary
Updated the wording of a publication title in the selected publications section for improved clarity and readability.

## Changes
- Revised publication title from "Spiking the training data to correct for test set contamination" to "Correcting test set contamination by spiking the training data"
  - The new phrasing leads with the main objective (correcting contamination) followed by the method (spiking training data)
  - Improves grammatical flow and emphasizes the primary goal of the work

https://claude.ai/code/session_011oGUk7DxsTCCimT3vwPesL